### PR TITLE
Build the Costumy Docs and Push to Github Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,52 @@
+name: Deploy Documentation to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install mkdocs mkdocs-material mkdocstrings[python] mkdocs-autorefs mkdocs-callouts
+
+      - name: Build documentation
+        run: mkdocs build --site-dir site
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./site
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 
-# Costumy
+# [Costumy](https://cdrinmatane.github.io/Costumy/)
 
 
 ![3D render of an interior scene. The foreground shows a floating tanktop in blue on the left. "Costumy" can be read on the right." ](docs/assets/media/costumy_banner.png)
 
 > [!WARNING]
-> Costumy is a prototype and has [limitations](docs/About/limitations.md).
+> Costumy is a prototype and has [limitations](https://cdrinmatane.github.io/Costumy/About/limitations/).
 
 ## Introduction
 
@@ -71,18 +71,18 @@ With those, you can :
 
 ## Installation
 
-See [Installation](docs/installation.md)
+See [Installation](https://cdrinmatane.github.io/Costumy/installation/)
 
 ## Complete Documentation
 
-Costumy has a nice static documentation, see [how to build docs](docs/Dev/docs.md)  
+Costumy has a nice [static documentation](https://cdrinmatane.github.io/Costumy/), see [how to build docs](https://cdrinmatane.github.io/Costumy/Dev/docs/)
 You have to install Costumy first, then serve the documentation locally.
 
 ![Screenshot of the docs](docs/assets/media/docs_screenshot.png)
 
 ## Credits
 
-Costumy was developped by [Christophe Marois](https://github.com/Qaqelol) within a [CDRIN](https://www.cdrin.com/) R&D project.  
+Costumy was developed by [Christophe Marois](https://github.com/Qaqelol) within a [CDRIN](https://www.cdrin.com/) R&D project.  
 
 Special Thanks to :
 
@@ -94,4 +94,4 @@ Special Thanks to :
 ## License
 
 This version of costumy is under GNU [GPL-3.0](https://www.gnu.org/licenses/gpl-3.0.html).  
-See [licences and credits](docs/About/licenses.md) for the complete list.
+See [licences and credits](https://cdrinmatane.github.io/Costumy/About/licenses/) for the complete list.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 # Requirements for the complete costumy experience
 -r requirements_2d.txt
+--extra-index-url https://download.blender.org/pypi/
 bpy==4.0.0          # Blender as a package for simulation and 3D renders
 triangle==20230923  # for a terrible way to create patterns topology in costumy.simulation


### PR DESCRIPTION
@cdrinmaroisc This PR builds Costumy's Docs with Github Actions and automatically pushes them to the Repo's Github Pages

This PR also adds the index URL for `bpy==4.0` since it's no longer LTS and thus no longer on pip.

## Live Example: https://zalo.github.io/Costumy/

Github Pages needs to be activated in the Repo's Settings before merging:
<img width="726" height="617" alt="image" src="https://github.com/user-attachments/assets/8c75d04b-3aff-4999-a4bf-7cd5d2f5f8eb" />